### PR TITLE
Fix docs and cleanup workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,7 +87,6 @@ jobs:
 
       - name: 8. Instalar Dependências da Aplicação
         run: |
-          python3 -m pip install numpy --user
           sudo apt-get update
           sudo apt-get install -y gettext-base jq curl
 

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 terraform.tfvars
 terraform.tfvars.json
 gha-creds-*.json             # credenciais do CI
+terraform/backend.hcl        # backend config (local only)
 
 # — Configs gerados pelos templates/pipeline —
 terraform/velocity/forwarding.secret

--- a/README.md
+++ b/README.md
@@ -29,6 +29,24 @@ The core principle of this architecture is to allow for easy modifications and s
 * **Highly Configurable:** Easily customize server and proxy settings through template files.
 * **Automated Backups:** Leverage Google Cloud Storage for automatic backups of your Minecraft world, with lifecycle policies to manage costs.
 
+## Quick Start
+
+1. Copy `terraform/backend.hcl.example` to `terraform/backend.hcl` and set your state bucket name.
+2. Copy `terraform/terraform.tfvars.example` to `terraform/terraform.tfvars` and fill in `project_id`, `region`, `zone`, `gcp_user_email`, `github_repo`, and `velocity_secret`.
+   The `velocity_secret` value is required by the Velocity proxy and must match the secret used in your server configuration.
+3. Run the bootstrap stack to create the bucket and service account:
+   ```bash
+   cd terraform/bootstrap
+   terraform init
+   terraform apply
+   ```
+4. Return to the main stack, initialize with the backend, and apply:
+   ```bash
+   cd ..
+   terraform init -backend-config=backend.hcl
+   terraform apply
+   ```
+
 ## 🚀 Technology Stack
 
 * **Cloud Provider:** Google Cloud Platform (GCP)
@@ -112,7 +130,7 @@ The pipelines reference the bucket and service account created in this step, so 
 
 ```bash
 cd ..
-terraform init
+terraform init -backend-config=backend.hcl
 terraform apply
 ```
 

--- a/terraform/backend.hcl
+++ b/terraform/backend.hcl
@@ -1,2 +1,0 @@
-bucket = "tfstate-server-mine-463823"
-prefix = "server-mine-v2/terraform"

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -5,3 +5,4 @@ region          = "YOUR_REGION_HERE"
 zone            = "YOUR_ZONE_HERE"
 gcp_user_email  = "YOUR_EMAIL"
 github_repo     = "YOUR GIT REPO HERE" # <-- CHANGE HERE FROM YOUR USER/REPO
+velocity_secret = "CHANGEME"


### PR DESCRIPTION
## Summary
- add quick start instructions in README
- mention velocity_secret usage
- ignore backend.hcl and remove the committed copy
- include velocity_secret placeholder in tfvars example
- drop unused numpy installation step

## Testing
- `terraform -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a978d2b0c8329bce04399d230520c